### PR TITLE
server: add runtime configuration and metadata-store dependencies (1/N)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,21 +17,16 @@ permissions:
 jobs:
   server-test:
     name: Server tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: server
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Check for server module
-        id: server
-        run: |
-          if [ -f server/pom.xml ]; then
-            echo "present=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - uses: actions/setup-java@v4
-        if: steps.server.outputs.present == 'true'
+      - name: Install Java 21
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: "21"
@@ -39,17 +34,11 @@ jobs:
           cache-dependency-path: server/pom.xml
 
       - name: Run tests
-        if: steps.server.outputs.present == 'true'
-        working-directory: server
         run: mvn -B -ntp verify
-
-      - name: Skip Maven tests
-        if: steps.server.outputs.present != 'true'
-        run: echo "No server/pom.xml in this revision; skipping Maven tests."
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: surefire-reports
           path: server/target/surefire-reports/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  server-test:
+    name: Server tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for server module
+        id: server
+        run: |
+          if [ -f server/pom.xml ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-java@v4
+        if: steps.server.outputs.present == 'true'
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          cache-dependency-path: server/pom.xml
+
+      - name: Run tests
+        if: steps.server.outputs.present == 'true'
+        working-directory: server
+        run: mvn -B -ntp verify
+
+      - name: Skip Maven tests
+        if: steps.server.outputs.present != 'true'
+        run: echo "No server/pom.xml in this revision; skipping Maven tests."
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: server/target/surefire-reports/
+          if-no-files-found: ignore

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,5 @@
+target/
+data/
+*.db
+*.mv.db
+*.trace.db

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,10 @@
+# OpenSharing Reference Server
+
+Reference implementation of the [OpenSharing](https://github.com/OpenSharing-IO/OpenSharing) protocol.
+
+## Build
+
+```bash
+cd server
+mvn test
+```

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.opensharing</groupId>
+  <artifactId>opensharing-server</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+
+  <name>OpenSharing Reference Server</name>
+  <description>Reference implementation of the OpenSharing protocol</description>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>21</maven.compiler.release>
+    <spring-boot.version>3.5.3</spring-boot.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -43,6 +43,28 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/server/src/main/java/io/opensharing/OpenSharingServer.java
+++ b/server/src/main/java/io/opensharing/OpenSharingServer.java
@@ -1,0 +1,12 @@
+package io.opensharing;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OpenSharingServer {
+
+  public static void main(String[] args) {
+    SpringApplication.run(OpenSharingServer.class, args);
+  }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,0 +1,66 @@
+# Defaults for a local run. Any key here can be overridden per environment without editing the file:
+# pass --the.key.path=value as an argument, or set the upper-case underscored form of the path, such as
+# OPENSHARING_ADMIN_BOOTSTRAP_TOKEN for opensharing.admin.bootstrap-token.
+spring:
+  application:
+    name: opensharing-server
+  datasource:
+    # The driver is derived from the URL, so pointing this at Postgres or MySQL is the only change
+    # needed to move the metadata store there.
+    url: jdbc:h2:file:./data/opensharing;AUTO_SERVER=TRUE
+    username: sa
+    password: ""
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+  jackson:
+    default-property-inclusion: non_null
+    mapper:
+      accept-case-insensitive-enums: true
+    serialization:
+      write-dates-as-timestamps: false
+
+server:
+  port: 8080
+  error:
+    whitelabel:
+      enabled: false
+
+opensharing:
+  # Prefix the protocol-serving endpoints are mounted under; this is what goes in a profile file.
+  protocol-prefix: /open-sharing
+  admin:
+    base-path: /api/admin/v1
+    # Registers the first principals and is accepted only on /principals. A random one is generated
+    # and logged at startup when this is blank.
+    bootstrap-token: ""
+  activation:
+    base-path: /activation
+    ttl: 72h
+    external-base-url: http://localhost:8080
+  recipient-tokens:
+    default-ttl: 90d
+    rotation-grace: 24h
+  asset-credentials:
+    ttl: 1h
+  pagination:
+    default-max-results: 500
+    max-max-results: 1000
+  delta:
+    # Reading Delta logs to serve version/metadata/query, and signing per-file urls from the
+    # credentials the catalog minted. Turning this off leaves dir access mode alone.
+    url-access-enabled: true
+    url-ttl: 1h
+    s3-region: us-east-1
+  catalog:
+    # 'local' reads every asset from a declarative file. It is the only connector this build ships.
+    type: local
+    local:
+      file: classpath:local-catalog.yml
+
+logging:
+  level:
+    io.opensharing: INFO
+    # Delta Kernel narrates every log segment it loads, which is a line per request.
+    io.delta: WARN

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,6 +1,5 @@
 # Defaults for a local run. Any key here can be overridden per environment without editing the file:
-# pass --the.key.path=value as an argument, or set the upper-case underscored form of the path, such as
-# OPENSHARING_ADMIN_BOOTSTRAP_TOKEN for opensharing.admin.bootstrap-token.
+# pass --the.key.path=value as an argument, or set the upper-case underscored form of the path.
 spring:
   application:
     name: opensharing-server
@@ -27,40 +26,6 @@ server:
     whitelabel:
       enabled: false
 
-opensharing:
-  # Prefix the protocol-serving endpoints are mounted under; this is what goes in a profile file.
-  protocol-prefix: /opensharing
-  admin:
-    base-path: /api/admin/v1
-    # Registers the first principals and is accepted only on /principals. A random one is generated
-    # and logged at startup when this is blank.
-    bootstrap-token: ""
-  activation:
-    base-path: /activation
-    ttl: 72h
-    external-base-url: http://localhost:8080
-  recipient-tokens:
-    default-ttl: 90d
-    rotation-grace: 24h
-  asset-credentials:
-    ttl: 1h
-  pagination:
-    default-max-results: 500
-    max-max-results: 1000
-  delta:
-    # Reading Delta logs to serve version/metadata/query, and signing per-file urls from the
-    # credentials the catalog minted. Turning this off leaves dir access mode alone.
-    url-access-enabled: true
-    url-ttl: 1h
-    s3-region: us-east-1
-  catalog:
-    # 'local' reads every asset from a declarative file. It is the only connector this build ships.
-    type: local
-    local:
-      file: classpath:local-catalog.yml
-
 logging:
   level:
     io.opensharing: INFO
-    # Delta Kernel narrates every log segment it loads, which is a line per request.
-    io.delta: WARN

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -29,7 +29,7 @@ server:
 
 opensharing:
   # Prefix the protocol-serving endpoints are mounted under; this is what goes in a profile file.
-  protocol-prefix: /open-sharing
+  protocol-prefix: /opensharing
   admin:
     base-path: /api/admin/v1
     # Registers the first principals and is accepted only on /principals. A random one is generated

--- a/server/src/test/java/io/opensharing/OpenSharingServerTest.java
+++ b/server/src/test/java/io/opensharing/OpenSharingServerTest.java
@@ -1,0 +1,11 @@
+package io.opensharing;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class OpenSharingServerTest {
+
+  @Test
+  void contextLoads() {}
+}


### PR DESCRIPTION
## Summary

Part **1/N**.

- `application.yml` defaults (Spring, H2 metadata store)
- JPA, validation, Jackson YAML, and H2 dependencies in `server/pom.xml`
- Minimal `server/README.md`

## Test plan

- [x] `cd server && mvn test`