### PR TITLE
server: add bearer-token utilities (3/N)

### DIFF
--- a/server/src/main/java/io/opensharing/auth/BearerTokens.java
+++ b/server/src/main/java/io/opensharing/auth/BearerTokens.java
@@ -1,0 +1,24 @@
+package io.opensharing.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+
+/** Extracts RFC 6750 bearer tokens from requests. */
+public final class BearerTokens {
+
+  private static final String SCHEME = "Bearer ";
+
+  private BearerTokens() {}
+
+  public static Optional<String> from(HttpServletRequest request) {
+    String header = request.getHeader("Authorization");
+    if (header == null || header.length() <= SCHEME.length()) {
+      return Optional.empty();
+    }
+    if (!header.regionMatches(true, 0, SCHEME, 0, SCHEME.length())) {
+      return Optional.empty();
+    }
+    String token = header.substring(SCHEME.length()).trim();
+    return token.isEmpty() ? Optional.empty() : Optional.of(token);
+  }
+}

--- a/server/src/main/java/io/opensharing/auth/Secrets.java
+++ b/server/src/main/java/io/opensharing/auth/Secrets.java
@@ -19,12 +19,12 @@ public final class Secrets {
 
   /** A new recipient bearer token. Returned to the caller once and never stored in clear text. */
   public static String newToken() {
-    return TOKEN_PREFIX + randomUrlSafe();
+    return TOKEN_PREFIX + randomToken();
   }
 
   /** A new single-use activation nonce. */
   public static String newActivationNonce() {
-    return randomUrlSafe();
+    return randomToken();
   }
 
   /** Lowercase hex SHA-256, the form persisted for tokens and nonces. */
@@ -37,7 +37,7 @@ public final class Secrets {
     }
   }
 
-  private static String randomUrlSafe() {
+  private static String randomToken() {
     byte[] bytes = new byte[TOKEN_BYTES];
     RANDOM.nextBytes(bytes);
     return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);

--- a/server/src/main/java/io/opensharing/auth/Secrets.java
+++ b/server/src/main/java/io/opensharing/auth/Secrets.java
@@ -1,0 +1,54 @@
+package io.opensharing.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HexFormat;
+
+/** Generates bearer tokens and activation nonces, and hashes them for storage. */
+public final class Secrets {
+
+  public static final String TOKEN_PREFIX = "os_";
+
+  private static final SecureRandom RANDOM = new SecureRandom();
+  private static final int TOKEN_BYTES = 32;
+
+  private Secrets() {}
+
+  /** A new recipient bearer token. Returned to the caller once and never stored in clear text. */
+  public static String newToken() {
+    return TOKEN_PREFIX + randomUrlSafe();
+  }
+
+  /** A new single-use activation nonce. */
+  public static String newActivationNonce() {
+    return randomUrlSafe();
+  }
+
+  /** Lowercase hex SHA-256, the form persisted for tokens and nonces. */
+  public static String sha256(String value) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is required but unavailable", e);
+    }
+  }
+
+  /** Constant-time comparison, for secrets compared outside the database. */
+  public static boolean constantTimeEquals(String a, String b) {
+    if (a == null || b == null) {
+      return false;
+    }
+    return MessageDigest.isEqual(
+        a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static String randomUrlSafe() {
+    byte[] bytes = new byte[TOKEN_BYTES];
+    RANDOM.nextBytes(bytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+  }
+}

--- a/server/src/main/java/io/opensharing/auth/Secrets.java
+++ b/server/src/main/java/io/opensharing/auth/Secrets.java
@@ -37,8 +37,8 @@ public final class Secrets {
     }
   }
 
-  /** Constant-time comparison, for secrets compared outside the database. */
-  public static boolean constantTimeEquals(String a, String b) {
+  /** Timing-safe comparison for secrets compared outside the database. */
+  public static boolean timingSafeEquals(String a, String b) {
     if (a == null || b == null) {
       return false;
     }

--- a/server/src/main/java/io/opensharing/auth/Secrets.java
+++ b/server/src/main/java/io/opensharing/auth/Secrets.java
@@ -37,15 +37,6 @@ public final class Secrets {
     }
   }
 
-  /** Timing-safe comparison for secrets compared outside the database. */
-  public static boolean timingSafeEquals(String a, String b) {
-    if (a == null || b == null) {
-      return false;
-    }
-    return MessageDigest.isEqual(
-        a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8));
-  }
-
   private static String randomUrlSafe() {
     byte[] bytes = new byte[TOKEN_BYTES];
     RANDOM.nextBytes(bytes);

--- a/server/src/test/java/io/opensharing/auth/SecretsTest.java
+++ b/server/src/test/java/io/opensharing/auth/SecretsTest.java
@@ -23,9 +23,9 @@ class SecretsTest {
   }
 
   @Test
-  void comparesInConstantTime() {
-    assertTrue(Secrets.constantTimeEquals("same", "same"));
-    assertFalse(Secrets.constantTimeEquals("same", "other"));
-    assertFalse(Secrets.constantTimeEquals(null, "other"));
+  void comparesTimingSafe() {
+    assertTrue(Secrets.timingSafeEquals("same", "same"));
+    assertFalse(Secrets.timingSafeEquals("same", "other"));
+    assertFalse(Secrets.timingSafeEquals(null, "other"));
   }
 }

--- a/server/src/test/java/io/opensharing/auth/SecretsTest.java
+++ b/server/src/test/java/io/opensharing/auth/SecretsTest.java
@@ -4,9 +4,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Base64;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 
 class SecretsTest {
+
+  private static final int TOKEN_BYTES = 32;
+  private static final int RANDOM_PART_LENGTH = (TOKEN_BYTES * 8 + 5) / 6; // unpadded Base64url
+  private static final Pattern URL_SAFE_BASE64 =
+      Pattern.compile("^[A-Za-z0-9_-]+$");
 
   @Test
   void hashesDeterministically() {
@@ -18,6 +25,21 @@ class SecretsTest {
   void mintsPrefixedTokens() {
     String token = Secrets.newToken();
     assertTrue(token.startsWith(Secrets.TOKEN_PREFIX));
+    assertEquals(Secrets.TOKEN_PREFIX.length() + RANDOM_PART_LENGTH, token.length());
+
+    String randomPart = token.substring(Secrets.TOKEN_PREFIX.length());
+    assertTrue(URL_SAFE_BASE64.matcher(randomPart).matches());
+    assertEquals(TOKEN_BYTES, Base64.getUrlDecoder().decode(randomPart).length);
+
     assertNotEquals(token, Secrets.newToken());
+  }
+
+  @Test
+  void mintsActivationNonces() {
+    String nonce = Secrets.newActivationNonce();
+    assertEquals(RANDOM_PART_LENGTH, nonce.length());
+    assertTrue(URL_SAFE_BASE64.matcher(nonce).matches());
+    assertEquals(TOKEN_BYTES, Base64.getUrlDecoder().decode(nonce).length);
+    assertNotEquals(nonce, Secrets.newActivationNonce());
   }
 }

--- a/server/src/test/java/io/opensharing/auth/SecretsTest.java
+++ b/server/src/test/java/io/opensharing/auth/SecretsTest.java
@@ -1,0 +1,31 @@
+package io.opensharing.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SecretsTest {
+
+  @Test
+  void hashesDeterministically() {
+    assertEquals(Secrets.sha256("hello"), Secrets.sha256("hello"));
+    assertNotEquals(Secrets.sha256("hello"), Secrets.sha256("world"));
+  }
+
+  @Test
+  void mintsPrefixedTokens() {
+    String token = Secrets.newToken();
+    assertTrue(token.startsWith(Secrets.TOKEN_PREFIX));
+    assertNotEquals(token, Secrets.newToken());
+  }
+
+  @Test
+  void comparesInConstantTime() {
+    assertTrue(Secrets.constantTimeEquals("same", "same"));
+    assertFalse(Secrets.constantTimeEquals("same", "other"));
+    assertFalse(Secrets.constantTimeEquals(null, "other"));
+  }
+}

--- a/server/src/test/java/io/opensharing/auth/SecretsTest.java
+++ b/server/src/test/java/io/opensharing/auth/SecretsTest.java
@@ -1,7 +1,6 @@
 package io.opensharing.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,12 +19,5 @@ class SecretsTest {
     String token = Secrets.newToken();
     assertTrue(token.startsWith(Secrets.TOKEN_PREFIX));
     assertNotEquals(token, Secrets.newToken());
-  }
-
-  @Test
-  void comparesTimingSafe() {
-    assertTrue(Secrets.timingSafeEquals("same", "same"));
-    assertFalse(Secrets.timingSafeEquals("same", "other"));
-    assertFalse(Secrets.timingSafeEquals(null, "other"));
   }
 }


### PR DESCRIPTION
## Summary

Part **3/N**.

Shared auth helpers for bootstrap admin, principals, and recipient tokens:

- `BearerTokens` — RFC 6750 bearer extraction from `Authorization` headers
- `Secrets` — bearer token minting (`os_` prefix + 32 random bytes, URL-safe Base64), activation nonces, and SHA-256 hashing for storage
- `SecretsTest` — deterministic hashing, token prefix/uniqueness, length, and URL-safe Base64 format

## Test plan

- [x] `cd server && mvn test`