### PR TITLE
server: add Scaffold Build Files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.watcherExclude": {
+        "**/target": true
+    }
+}

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,5 @@
+target/
+data/
+*.db
+*.mv.db
+*.trace.db

--- a/server/.mvn/local-mirror-settings.xml
+++ b/server/.mvn/local-mirror-settings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Machine-local workaround, not a project requirement.
+
+  This developer machine resolves repo.maven.apache.org and repo1.maven.org to 127.0.0.1 through
+  /etc/hosts, so Maven cannot reach Central. This settings file points Maven at Google's official
+  read-only mirror of Maven Central instead.
+
+  Use it explicitly:  mvn -s .mvn/local-mirror-settings.xml <goals>
+
+  On a machine with normal access to Central, ignore this file entirely.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>google-maven-central</id>
+      <name>Google mirror of Maven Central</name>
+      <url>https://maven-central-eu.storage-download.googleapis.com/maven2</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/server/opensharing-server-core/pom.xml
+++ b/server/opensharing-server-core/pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.opensharing</groupId>
+    <artifactId>opensharing-parent</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>opensharing-server-core</artifactId>
+
+  <name>OpenSharing Server Core</name>
+  <description>Embeddable OpenSharing library for hosts such as Unity Catalog OSS</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springdoc</groupId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+      <version>${springdoc.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.delta</groupId>
+      <artifactId>delta-kernel-defaults</artifactId>
+      <version>${delta-kernel.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client-api</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-client-runtime</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>bundle</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+      <version>${aws-sdk.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3-transfer-manager</artifactId>
+      <version>${aws-sdk.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>${aws-sdk.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache-client</artifactId>
+      <version>${aws-sdk.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-azure</artifactId>
+      <version>${hadoop.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud.bigdataoss</groupId>
+      <artifactId>gcs-connector</artifactId>
+      <version>${gcs-connector.version}</version>
+      <classifier>shaded</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/server/opensharing-server/pom.xml
+++ b/server/opensharing-server/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.opensharing</groupId>
+    <artifactId>opensharing-parent</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>opensharing-server</artifactId>
+
+  <name>OpenSharing Reference Server</name>
+  <description>Runnable OpenSharing server for standalone deployments</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opensharing</groupId>
+      <artifactId>opensharing-server-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>io.opensharing.OpenSharingServer</mainClass>
+          <classifier>exec</classifier>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/server/opensharing-server/src/main/resources/application.yml
+++ b/server/opensharing-server/src/main/resources/application.yml
@@ -1,0 +1,86 @@
+# Defaults for a local run. Any key here can be overridden per environment without editing the file:
+# pass --the.key.path=value as an argument, or set the upper-case underscored form of the path.
+spring:
+  application:
+    name: opensharing-server
+  datasource:
+    # The driver is derived from the URL, so pointing this at Postgres or MySQL is the only change
+    # needed to move the metadata store there.
+    url: jdbc:h2:file:./data/opensharing;AUTO_SERVER=TRUE
+    username: sa
+    password: ""
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+  jackson:
+    default-property-inclusion: non_null
+    mapper:
+      accept-case-insensitive-enums: true
+    serialization:
+      write-dates-as-timestamps: false
+
+server:
+  port: 8080
+  error:
+    whitelabel:
+      enabled: false
+
+opensharing:
+  # Prefix the protocol-serving endpoints are mounted under; this is what goes in a profile file.
+  protocol-prefix: /api/2.1/opensharing
+  hosting:
+    # standalone: run as its own Spring Boot process with opensharing.catalog.* and admin principals.
+    # embedded: host registers a CatalogConnector bean (see io.opensharing.runtime.OpenSharing).
+    mode: standalone
+  admin:
+    # Provider principals provisioned at startup. Each bearer token is also the credential the
+    # catalog is asked with as that principal.
+    principals: []
+  provider:
+    base-path: /api/2.1/opensharing/provider
+  activation:
+    base-path: /api/2.1/opensharing/activation
+    ttl: 72h
+    external-base-url: http://localhost:8080
+  recipient-tokens:
+    default-ttl: 90d
+    rotation-grace: 24h
+  asset-credentials:
+    ttl: 1h
+  pagination:
+    default-max-results: 500
+    max-max-results: 1000
+  storage:
+    # Region used to sign S3 urls when the catalog's credentials do not name one.
+    s3-region: us-east-1
+    # A Google service account key file, whose private key signs urls for gs paths. Google signs with
+    # RSA, so a key is the only thing that can, and the OAuth token a catalog vends cannot go in a
+    # url. Blank leaves GOOGLE_APPLICATION_CREDENTIALS to name the file, as the reference sharing
+    # server does; with neither, Google storage is served in dir access mode only.
+    gcs-service-account-key-file: ""
+  delta:
+    # Reading Delta logs to serve version/metadata/query, and signing per-file urls from the
+    # credentials the catalog minted. Turning this off leaves dir access mode alone.
+    url-access-enabled: true
+    url-ttl: 1h
+  catalog:
+    # 'local' reads every asset from a declarative file; 'unity' asks an open-source Unity Catalog
+    # over its REST API, as whichever principal the request is for.
+    type: local
+    local:
+      file: classpath:local-catalog.yml
+    unity:
+      # Base url of the Unity Catalog API, the path it is served under included. Required when the
+      # type above is 'unity'. Nothing authenticates to the catalog on the server's own behalf, so no
+      # credential belongs here. Note that Unity Catalog also listens on 8080 by default, so one
+      # running beside this server will have been moved off it.
+      uri: ""
+      connect-timeout: 5s
+      request-timeout: 30s
+
+logging:
+  level:
+    io.opensharing: INFO
+    # Delta Kernel narrates every log segment it loads, which is a line per request.
+    io.delta: WARN

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.opensharing</groupId>
+  <artifactId>opensharing-parent</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>OpenSharing</name>
+  <description>Reference implementation of the OpenSharing protocol</description>
+
+  <modules>
+    <module>opensharing-server-core</module>
+    <module>opensharing-server</module>
+  </modules>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.release>21</maven.compiler.release>
+    <spring-boot.version>3.5.3</spring-boot.version>
+    <delta-kernel.version>4.0.0</delta-kernel.version>
+    <hadoop.version>3.4.3</hadoop.version>
+    <aws-sdk.version>2.35.4</aws-sdk.version>
+    <gcs-connector.version>hadoop3-2.2.30</gcs-connector.version>
+    <springdoc.version>2.9.0</springdoc.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.opensharing</groupId>
+        <artifactId>opensharing-server-core</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.13.0</version>
+          <configuration>
+            <compilerArgs>
+              <arg>-parameters</arg>
+            </compilerArgs>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.2.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${spring-boot.version}</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>


### PR DESCRIPTION
Part of splitting #14 into small, stacked, reviewable PRs (see #18 for the CI foundation this stacks on). Stacks on `ci/github-actions`.

Scoped to local catalog only for now: Unity Catalog connector, Iceberg REST catalog, and pre-signed-URL (Delta log replay / per-file signing) support are deferred to a later batch — see the tracking note in the top-of-stack PR.

## Test plan
- [x] `cd server && mvn test`