### PR TITLE
server: add Admin Json

### DIFF
--- a/server/opensharing-server-core/src/main/java/io/opensharing/http/AdminJson.java
+++ b/server/opensharing-server-core/src/main/java/io/opensharing/http/AdminJson.java
@@ -1,0 +1,19 @@
+package io.opensharing.http;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a provider-admin request or response body. The admin API speaks snake_case, unlike the
+ * recipient-facing protocol, which is camelCase and must stay that way for Delta Sharing clients.
+ */
+@JacksonAnnotationsInside
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface AdminJson {}


### PR DESCRIPTION
Part of splitting #14 into small, stacked, reviewable PRs (see #18 for the CI foundation this stacks on). Stacks on `server/split/001-scaffold-build-files`.

Scoped to local catalog only for now: Unity Catalog connector, Iceberg REST catalog, and pre-signed-URL (Delta log replay / per-file signing) support are deferred to a later batch — see the tracking note in the top-of-stack PR.

## Test plan
- [x] `cd server && mvn test`