### PR TITLE
server: add Protocol Media Type

### DIFF
--- a/server/opensharing-server-core/src/main/java/io/opensharing/http/ProtocolMediaType.java
+++ b/server/opensharing-server-core/src/main/java/io/opensharing/http/ProtocolMediaType.java
@@ -1,0 +1,15 @@
+package io.opensharing.http;
+
+/**
+ * Content types the spec requires on successful protocol responses. Both are spelled the way a
+ * parsed media type renders, so the published API lists each of them once.
+ */
+public final class ProtocolMediaType {
+
+  public static final String JSON_UTF8 = "application/json;charset=utf-8";
+
+  /** The read operations answer in newline-delimited JSON, one action per line. */
+  public static final String NDJSON_UTF8 = "application/x-ndjson;charset=utf-8";
+
+  private ProtocolMediaType() {}
+}


### PR DESCRIPTION
Part of splitting #14 into small, stacked, reviewable PRs (see #18 for the CI foundation this stacks on). Stacks on `server/split/003-offset-page`.

Scoped to local catalog only for now: Unity Catalog connector, Iceberg REST catalog, and pre-signed-URL (Delta log replay / per-file signing) support are deferred to a later batch — see the tracking note in the top-of-stack PR.

## Test plan
- [x] `cd server && mvn test`