### PR TITLE
server: add Aws Credentials

### DIFF
--- a/server/opensharing-server-core/src/main/java/io/opensharing/protocol/AwsCredentials.java
+++ b/server/opensharing-server-core/src/main/java/io/opensharing/protocol/AwsCredentials.java
@@ -1,0 +1,3 @@
+package io.opensharing.protocol;
+
+public record AwsCredentials(String accessKeyId, String secretAccessKey, String sessionToken) {}

--- a/server/opensharing-server-core/src/main/java/io/opensharing/protocol/AzureUserDelegationSas.java
+++ b/server/opensharing-server-core/src/main/java/io/opensharing/protocol/AzureUserDelegationSas.java
@@ -1,0 +1,3 @@
+package io.opensharing.protocol;
+
+public record AzureUserDelegationSas(String sasToken) {}

--- a/server/opensharing-server-core/src/main/java/io/opensharing/protocol/GcpOauthToken.java
+++ b/server/opensharing-server-core/src/main/java/io/opensharing/protocol/GcpOauthToken.java
@@ -1,0 +1,3 @@
+package io.opensharing.protocol;
+
+public record GcpOauthToken(String oauthToken) {}

--- a/server/opensharing-server-core/src/main/java/io/opensharing/protocol/R2Credentials.java
+++ b/server/opensharing-server-core/src/main/java/io/opensharing/protocol/R2Credentials.java
@@ -1,0 +1,3 @@
+package io.opensharing.protocol;
+
+public record R2Credentials(String accessKeyId, String secretAccessKey, String sessionToken) {}

--- a/server/opensharing-server-core/src/main/java/io/opensharing/protocol/TemporaryCredentials.java
+++ b/server/opensharing-server-core/src/main/java/io/opensharing/protocol/TemporaryCredentials.java
@@ -1,0 +1,32 @@
+package io.opensharing.protocol;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+/**
+ * Response of the {@code temporary-table-credentials} endpoint. Exactly one of the cloud-specific
+ * fields is populated; {@code expirationTime} is epoch milliseconds.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record TemporaryCredentials(
+    AwsCredentials awsTempCredentials,
+    AzureUserDelegationSas azureUserDelegationSas,
+    GcpOauthToken gcpOauthToken,
+    R2Credentials r2Credentials,
+    long expirationTime) {
+
+  public static TemporaryCredentials aws(AwsCredentials credentials, long expirationTime) {
+    return new TemporaryCredentials(credentials, null, null, null, expirationTime);
+  }
+
+  public static TemporaryCredentials azure(AzureUserDelegationSas sas, long expirationTime) {
+    return new TemporaryCredentials(null, sas, null, null, expirationTime);
+  }
+
+  public static TemporaryCredentials gcp(GcpOauthToken token, long expirationTime) {
+    return new TemporaryCredentials(null, null, token, null, expirationTime);
+  }
+
+  public static TemporaryCredentials r2(R2Credentials credentials, long expirationTime) {
+    return new TemporaryCredentials(null, null, null, credentials, expirationTime);
+  }
+}


### PR DESCRIPTION
Part of splitting #14 into small, stacked, reviewable PRs (see #18 for the CI foundation this stacks on). Stacks on `server/split/004-protocol-media-type`.

Scoped to local catalog only for now: Unity Catalog connector, Iceberg REST catalog, and pre-signed-URL (Delta log replay / per-file signing) support are deferred to a later batch — see the tracking note in the top-of-stack PR.

## Test plan
- [x] `cd server && mvn test`